### PR TITLE
Implement base stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /dist
 /node_modules
 /config.local.js
+.*.swp
+.*.swo

--- a/AbilityDeck.jsx
+++ b/AbilityDeck.jsx
@@ -6,6 +6,7 @@ import AbilityCardFront from './AbilityCardFront';
 import ButtonDiv from './ButtonDiv';
 import Card from './Card';
 import DeckState from './DeckState';
+import StatIcon from './StatIcon';
 import { DECKS } from './cards';
 import { attributes_to_lines, immunities_to_lines, notes_to_lines, special_to_lines } from './macros';
 import { MONSTER_STATS } from './monster_stats';
@@ -24,6 +25,7 @@ export default function AbilityDeck(props) {
   let range = [0, 0];
   let health = [0, 0];
   let extra_lines = [];
+  let attributes = [];
   const isBoss = spec.class === DECKS.Boss.class;
   if (isBoss && spec.name !== 'Boss') {
     const bossName = spec.name.replace('Boss: ', '');
@@ -44,8 +46,50 @@ export default function AbilityDeck(props) {
     move = [stats.normal.move, stats.elite.move];
     range = [stats.normal.range, stats.elite.range];
     health = [stats.normal.health, stats.elite.health];
-    const attributes = [stats.normal.attributes, stats.elite.attributes];
+    attributes = [stats.normal.attributes, stats.elite.attributes];
     extra_lines = extra_lines.concat(attributes_to_lines(attributes));
+  }
+
+  // Parse the attributes and store them in structures we will use when we need to render base
+  // stats.  We divide attributes into three categories.
+  // 1) Integer attributes.  Things like, "Shield 5" or "Target 2", or even "Retaliate 2: Range 2".
+  // 2) Bool attributes.  Things like "Flying", or "Poison".
+  // 3) Text attributes.  Things like "Attacker gains disadvantage"
+  const attr_parse = /^%(\S+)%(\s+([0-9]+))?(:\s*%(\S+)%(\s+([0-9]+)))?$/;
+  const int_attr_dict = { };
+  const txt_attr_dict = { };
+  const bool_attrs = [[], []];
+  for (const i in attributes) {
+    for (const j in attributes[i]) {
+      const text = attributes[i][j];
+      const match = attr_parse.exec(text);
+      const name = match ? match[1] : text;
+
+      if (!match) {
+        // No match => Text attribute
+        if (!(name in txt_attr_dict)) {
+          txt_attr_dict[name] = [0, 0];
+        }
+        txt_attr_dict[name][i] = 1;
+      } else
+      if (!match[3]) {
+        // No number after the icon => bool attribute
+        bool_attrs[i].push(name);
+      } else {
+        // Must be an integer attribute, perhaps with an extra modifier.
+        if (!(name in int_attr_dict)) {
+          int_attr_dict[name] = [[0], [0]];
+        }
+
+        int_attr_dict[name][i] = [match[3]];
+        if (match[5]) {
+          int_attr_dict[name][i].push(match[5]);
+          if (match[7]) {
+            int_attr_dict[name][i].push(match[7]);
+          }
+        }
+      }
+    }
   }
 
   const renderCard = (card, zIndex, cardClasses, faceUp) => {
@@ -86,22 +130,146 @@ export default function AbilityDeck(props) {
     );
   };
 
+  const renderBaseStats = () => {
+    if (!props.showBaseStats) {
+      return null;
+    }
+
+    // Transform [a, b, c, ...] into [[a], [b], [c], ...]
+    const wrap_array = x => x.map(y => [y]);
+
+    const intStatLine = (iconName, data) => {
+      const bossData = (data.length === 1);
+      const empty = (data[0][0] === 0) && (bossData || (data[1][0] === 0));
+      if (empty) {
+        return null;
+      }
+
+      const render_val = val => val.map((v, k) => {
+        if ((k % 2) != 0) {
+          return <StatIcon name={v} className={css.intStatIcon} />;
+        }
+        return (v == 0) ? '-' : String(v);
+      });
+
+      return bossData
+        ? (
+          <tr>
+            <td className={css.baseStateId}>
+              <StatIcon name={iconName} className={css.intStatIcon} />
+            </td>
+            <td className={css.baseStatRight}>{render_val(data[0])}</td>
+          </tr>
+        )
+        : (
+          <tr>
+            <td className={css.baseStatLeft}>{render_val(data[0])}</td>
+            <td className={css.baseStatId}>
+              <StatIcon name={iconName} className={css.intStatIcon} />
+            </td>
+            <td className={css.baseStatRight}>{render_val(data[1])}</td>
+          </tr>
+        );
+    };
+
+    const boolStatLine = (mobType, data) => {
+      if (!data.length) {
+        return null;
+      }
+
+      const icons = data.map(iconName => <StatIcon name={iconName} className={css.boolStatIcon} />);
+      return (
+        <tr>
+          <td>{mobType}</td>
+          <td>{icons}</td>
+        </tr>
+      );
+    };
+
+    const attr_lines = Object.keys(int_attr_dict).map(key =>
+      intStatLine(key, int_attr_dict[key]));
+
+    return (
+      <div className={css.baseStats}>
+        <table>
+          { intStatLine('heal', wrap_array(health)) }
+          { intStatLine('move', wrap_array(move)) }
+          { intStatLine('attack', wrap_array(attack)) }
+          { intStatLine('range', wrap_array(range)) }
+          {attr_lines}
+        </table>
+        { (bool_attrs[0].length || bool_attrs[1].length) ? <hr /> : null }
+        <table>
+          { boolStatLine('N', bool_attrs[0]) }
+          { boolStatLine('E', bool_attrs[1]) }
+        </table>
+      </div>
+    );
+  };
+
+  const renderBossExtras = () => {
+    const text_attrs = Object.keys(txt_attr_dict).map((key) => {
+      const who = txt_attr_dict[key];
+      let modifier = null;
+      if (!who[0]) {
+        modifier = ' (elite only)';
+      } else
+      if (!who[1]) {
+        modifier = ' (normal only)';
+      }
+      return <li>{key}{modifier}</li>;
+    });
+
+    const immunity_line = () => {
+      if (!stats.immunities) {
+        return null;
+      }
+
+      const Icon = x => <StatIcon name={x} className={css.boolStatIcon} />;
+      const icons = stats.immunities
+        ? Object.keys(stats.immunities).map(key => Icon(stats.immunities[key]))
+        : null;
+      return <li>Immunities: {icons}</li>;
+    };
+
+    const notes = () => (stats.notes ? <li>{stats.notes}</li> : null);
+
+    return (
+      <div className={css.baseStats}>
+        <ul>
+          { text_attrs }
+          { immunity_line() }
+          { notes() }
+        </ul>
+      </div>
+    );
+  };
+
   const [topDraw] = props.deckState.draw_pile;
   const [topDiscard, sndDiscard] = props.deckState.discard;
   return (
-    <ButtonDiv
-      className={props.hidden ? css.hiddenDeck : css.cardContainer}
-      onClick={props.onClick}
+    <div
+      className={props.hidden ? css.hiddenDeck : css.abilityDeckContainer}
     >
-      {topDraw ? renderCard(topDraw, -7, [css.draw], false) : null}
-      {topDiscard ? renderCard(topDiscard, -3, [css.discard, css.pull], true) : null}
-      {sndDiscard ? renderCard(sndDiscard, -4, [css.discard, css.lift], true) : null}
-    </ButtonDiv>
+      <div className={css.rowContainer}>
+        <ButtonDiv
+          className={css.cardContainer}
+          onClick={props.onClick}
+        >
+          {topDraw ? renderCard(topDraw, -7, [css.draw], false) : null}
+          {topDiscard ? renderCard(topDiscard, -3, [css.discard, css.pull], true) : null}
+          {sndDiscard ? renderCard(sndDiscard, -4, [css.discard, css.lift], true) : null}
+        </ButtonDiv>
+        { props.showBaseStats ? renderBaseStats() : null }
+      </div>
+      { props.showBaseStats ? renderBossExtras() : null }
+    </div>
   );
 }
 
 AbilityDeck.defaultProps = {
   hidden: false,
+  showBaseStats: false,
 };
 
 AbilityDeck.propTypes = {
@@ -114,4 +282,5 @@ AbilityDeck.propTypes = {
   deckState: PropTypes.instanceOf(DeckState).isRequired,
   onClick: PropTypes.func.isRequired,
   hidden: PropTypes.bool,
+  showBaseStats: PropTypes.bool,
 };

--- a/AbilityDeck.jsx
+++ b/AbilityDeck.jsx
@@ -247,6 +247,8 @@ export default function AbilityDeck(props) {
 
   const [topDraw] = props.deckState.draw_pile;
   const [topDiscard, sndDiscard] = props.deckState.discard;
+  const pullAnim = props.showFlip ? css.pull : null;
+  const liftAnim = props.showFlip ? css.lift : null;
   return (
     <div
       className={props.hidden ? css.hiddenDeck : css.abilityDeckContainer}
@@ -257,8 +259,8 @@ export default function AbilityDeck(props) {
           onClick={props.onClick}
         >
           {topDraw ? renderCard(topDraw, -7, [css.draw], false) : null}
-          {topDiscard ? renderCard(topDiscard, -3, [css.discard, css.pull], true) : null}
-          {sndDiscard ? renderCard(sndDiscard, -4, [css.discard, css.lift], true) : null}
+          {topDiscard ? renderCard(topDiscard, -3, [css.discard, pullAnim], true) : null}
+          {sndDiscard ? renderCard(sndDiscard, -4, [css.discard, liftAnim], true) : null}
         </ButtonDiv>
         { props.showBaseStats ? renderBaseStats() : null }
       </div>
@@ -281,6 +283,7 @@ AbilityDeck.propTypes = {
   }).isRequired,
   deckState: PropTypes.instanceOf(DeckState).isRequired,
   onClick: PropTypes.func.isRequired,
+  showFlip: PropTypes.bool.isRequired,
   hidden: PropTypes.bool,
   showBaseStats: PropTypes.bool,
 };

--- a/MainUI.jsx
+++ b/MainUI.jsx
@@ -25,21 +25,46 @@ SettingsButton.propTypes = {
   onClick: PropTypes.func.isRequired,
 };
 
-function VisibilityMenu(props) {
-  const { onToggleVisibility } = props;
-  const entries = props.deckSpecs.map(spec => (
-    <li className={TableauCss.currentDeck} key={spec.id}>
-      <ButtonDiv className={TableauCss.button} onClick={() => onToggleVisibility(spec.id)}>
-        {spec.name}
+function VisibilityButton(props) {
+  return (
+    <li className={TableauCss.currentDeck} key={props.id}>
+      <ButtonDiv
+        className={TableauCss.button}
+        onClick={() => props.onClick()}
+      >
+        {props.name}
       </ButtonDiv>
     </li>
+  );
+}
+
+VisibilityButton.propTypes = {
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+function VisibilityMenu(props) {
+  const { onToggleVisibility, onToggleBaseStats } = props;
+  const entries = props.deckSpecs.map(spec => (
+    <VisibilityButton
+      id={spec.id}
+      name={spec.name}
+      onClick={() => onToggleVisibility(spec.id)}
+    />
   ));
-  return <ul className={TableauCss.currentDeckList}>{entries}</ul>;
+  return (
+    <ul className={TableauCss.currentDeckList}>
+      <VisibilityButton id="0" name="Base Stats" onClick={onToggleBaseStats} />
+      {entries}
+    </ul>
+  );
 }
 
 VisibilityMenu.propTypes = {
   deckSpecs: PropTypes.arrayOf(PropTypes.object).isRequired,
   onToggleVisibility: PropTypes.func.isRequired,
+  onToggleBaseStats: PropTypes.func.isRequired,
 };
 
 class MainUI extends React.Component {
@@ -47,15 +72,22 @@ class MainUI extends React.Component {
     deckSpecs: storageValueProp(PropTypes.array).isRequired,
     deckVisible: storageValueProp(PropTypes.object).isRequired,
     modDeckHidden: storageValueProp(PropTypes.bool).isRequired,
+    showBaseStats: storageValueProp(PropTypes.bool).isRequired,
   }
 
-  state = { settingsVisible: true }
+  state = {
+    settingsVisible: true,
+  }
 
   tableau = React.createRef();
 
   handleDeckVisibilityToggle = (deckId) => {
     const mutation = deckVis => ({ ...deckVis, [deckId]: !deckVis[deckId] });
     this.props.deckVisible.mutate(mutation);
+  }
+
+  handleBaseStatsToggle = () => {
+    this.props.showBaseStats.mutate(showBase => !showBase);
   }
 
   handleSelectDecks = (deckSpecs, showModifierDeck, preserve) => {
@@ -89,12 +121,14 @@ class MainUI extends React.Component {
           <VisibilityMenu
             deckSpecs={this.props.deckSpecs.value}
             onToggleVisibility={this.handleDeckVisibilityToggle}
+            onToggleBaseStats={this.handleBaseStatsToggle}
           />
         </div>
         <Tableau
           deckSpecs={this.props.deckSpecs.value}
           deckVisible={this.props.deckVisible.value}
           modDeckHidden={this.props.modDeckHidden.value}
+          showBaseStats={this.props.showBaseStats.value}
           ref={this.tableau}
         />
       </React.Fragment>
@@ -114,5 +148,9 @@ export default withStorage(MainUI, {
   modDeckHidden: {
     path: 'mod_deck_hidden',
     deserialize: value => (typeof value === 'boolean' ? value : true),
+  },
+  showBaseStats: {
+    path: 'mod_deck_hidden',
+    deserialize: value => (typeof value === 'boolean' ? value : false),
   },
 });

--- a/StatIcon.jsx
+++ b/StatIcon.jsx
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import classNames from 'classnames';
+import * as css from './style/Card.scss';
+
+const REMAP_LUT = {
+  flying: { invert: true, icon: 'images/fly.svg' },
+  attack: { invert: true },
+  heal: { invert: true },
+  jump: { invert: true },
+  loot: { invert: true },
+  move: { invert: true },
+  pull: { invert: true },
+  push: { invert: true },
+  range: { invert: true },
+  retaliate: { invert: true },
+  shield: { invert: true },
+  target: { invert: true },
+};
+
+export default function StatIcon(props) {
+  const parse = /^%?([^%]+)%?$/;
+  const match = parse.exec(props.name);
+  const cnames = [props.className];
+  let img_src = `images/${match[1]}.svg`;
+
+  if (REMAP_LUT[match[1]]) {
+    const entry = REMAP_LUT[match[1]];
+
+    if (entry.icon) {
+      img_src = entry.icon;
+    }
+
+    if (entry.invert) {
+      cnames.push(css.invertIcon);
+    }
+  }
+
+  return <img className={classNames(cnames)} src={img_src} alt="" />;
+}
+
+StatIcon.defaultProps = {
+  className: [],
+};
+
+StatIcon.propTypes = {
+  name: PropTypes.string.isRequired,
+  className: PropTypes.string,
+};

--- a/Tableau.jsx
+++ b/Tableau.jsx
@@ -44,6 +44,7 @@ class Tableau extends React.Component {
     deckVisible: PropTypes.objectOf(PropTypes.bool).isRequired,
     modDeckHidden: PropTypes.bool.isRequired,
     modDeckState: storageValueProp(PropTypes.object).isRequired,
+    showBaseStats: PropTypes.bool.isRequired,
   }
 
   componentDidMount() {
@@ -121,6 +122,7 @@ class Tableau extends React.Component {
           deckState={this.props.deckState.value[spec.class]}
           onClick={() => this.handleDeckClick(spec.class)}
           hidden={!this.props.deckVisible[spec.id]}
+          showBaseStats={this.props.showBaseStats}
         />
       );
     });

--- a/Tableau.jsx
+++ b/Tableau.jsx
@@ -71,6 +71,10 @@ class Tableau extends React.Component {
     window.removeEventListener('resize', refresh_ui);
   }
 
+  // lastFlippedDeckClass keeps track of the class of deck which most recently
+  // had a card drawn on it, but has not yet been rendererd.
+  lastFlippedDeckClass = null;
+
   handleDeckClick(deckClass) {
     const mutation = deckState => ({
       ...deckState,
@@ -79,6 +83,7 @@ class Tableau extends React.Component {
         deckState[deckClass].draw_card(),
     });
     this.props.deckState.mutate(mutation);
+    this.lastFlippedDeckClass = deckClass;
   }
 
   mutateModDeck(mutation) {
@@ -123,9 +128,12 @@ class Tableau extends React.Component {
           onClick={() => this.handleDeckClick(spec.class)}
           hidden={!this.props.deckVisible[spec.id]}
           showBaseStats={this.props.showBaseStats}
+          showFlip={this.lastFlippedDeckClass === spec.class}
         />
       );
     });
+
+    this.lastFlippedDeckClass = null;
 
     return (
       <div id={css.tableau} style={{ fontSize: '26.6px' }}>

--- a/style/Card.scss
+++ b/style/Card.scss
@@ -5,6 +5,65 @@ $card-ratio: $card-width / 296px;
   display: none;
 }
 
+.ability-deck-container {
+  max-width: 100vw;
+}
+
+.row-container {
+  display: flex;
+  flex-flow: row nowrap;
+}
+
+.base-stats {
+  font-family: 'Nyala', 'Sakkal Majalla', 'Philosopher', sans-serif;
+  font-size: 85%;
+
+  // Styles for the stats icon table (right of card)
+  table {
+    border-spacing: 0;
+  }
+
+  .base-stat-id {
+    text-align: center;
+  }
+
+  .base-stat-left {
+    text-align: right;
+  }
+
+  .base-stat-right {
+    text-align: left;
+  }
+
+  // Style for the separator between int and bool stats (right of card).
+  hr {
+    border-style: solid;
+    margin: 0;
+  }
+
+  // Styles for the stats list (below card)
+  ul {
+    list-style: none;
+    margin: 0;
+  }
+
+  // Styles for icons used by the base stats display.
+  .int-stat-icon {
+    height: .75em;
+    vertical-align: baseline;
+  }
+
+  .bool-stat-icon {
+    height: .85em;
+    margin-right: .15em;
+    vertical-align: baseline;
+  }
+
+  .invert-icon {
+    filter: invert(100%);
+  }
+}
+
 @media only screen and (min-height: 500px) and (orientation: portrait) {
   .card-container {
     max-width: 33vh * $card-ratio;


### PR DESCRIPTION
So here is my first crack at trying to make the base statistics for a mob available for display next to their deck.  It seems to lay out reasonably well when on a vertical tablet (My group plays with a tablet on a music stand mount next to the table).  I'm not sure it is all that great layout-wise in a normal browser; suggestions and advice are welcome.

This should address issue #1 