### PR TITLE
Fix modifier deck visibility issues when showing base stats

### DIFF
--- a/MainUI.jsx
+++ b/MainUI.jsx
@@ -150,7 +150,7 @@ export default withStorage(MainUI, {
     deserialize: value => (typeof value === 'boolean' ? value : true),
   },
   showBaseStats: {
-    path: 'mod_deck_hidden',
+    path: 'show_base_stats',
     deserialize: value => (typeof value === 'boolean' ? value : false),
   },
 });


### PR DESCRIPTION
This would only occur if Firebase was enabled.

Fixes issue #9.