### PR TITLE
Improve scenario level/number selectors

### DIFF
--- a/LevelSelector.jsx
+++ b/LevelSelector.jsx
@@ -31,7 +31,7 @@ export default class LevelSelector extends React.Component {
       // We take the value mod 10, so that we can make the latest entered digit override
       // the field value
       let value = parseInt(event.target.value) % 10;
-      if (isNaN(value) || value < 0) {
+      if (Number.isNaN(value) || value < 0) {
         value = 0;
       } else if (value > MAX_LEVEL) {
         value = MAX_LEVEL;

--- a/LevelSelector.jsx
+++ b/LevelSelector.jsx
@@ -41,20 +41,20 @@ export default class LevelSelector extends React.Component {
       this.props.onChange(value);
     };
 
-    const handleFocus = (event) => event.target.select();
+    const handleFocus = event => event.target.select();
 
     return (
       <Wrapper className={selectionList}>
-      <Label>{this.props.text}</Label>
-      <input
-      name="scenario_level"
-      type="text"
-      pattern="[0-9]*"
-      inputmode="numeric"
-      value={this.state.textValue}
-      onChange={onChange}
-      onFocus={handleFocus}
-      />
+        <Label>{this.props.text}</Label>
+        <input
+          name="scenario_level"
+          type="text"
+          pattern="[0-9]*"
+          inputMode="numeric"
+          value={this.state.textValue}
+          onChange={onChange}
+          onFocus={handleFocus}
+        />
       </Wrapper>
     );
   }

--- a/ScenarioList.jsx
+++ b/ScenarioList.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
 
 import LevelSelector from './LevelSelector';
+import ScenarioSelector from './ScenarioSelector';
 import { makeDeckSpec } from './cards';
 import { SCENARIO_DEFINITIONS, SPECIAL_RULES } from './scenarios';
 
 import { selectionList } from './style/SettingsPane.scss';
 
 export default class ScenarioList extends React.Component {
-  state = { level: 1, scenario: 0 };
+  state = { level: 1, scenario: 1 };
 
   getScenarioDecks() {
-    const { decks, special_rules: specialRules = [] } = SCENARIO_DEFINITIONS[this.state.scenario];
+    const { decks, special_rules: specialRules = [] } = SCENARIO_DEFINITIONS[this.state.scenario-1];
     return decks.map(({ name }) => {
       let level = this.state.level;
       if ((specialRules.indexOf(SPECIAL_RULES.living_corpse_two_levels_extra) >= 0) && (name == SPECIAL_RULES.living_corpse_two_levels_extra.affected_deck)) {
@@ -24,10 +25,8 @@ export default class ScenarioList extends React.Component {
     this.setState({ level });
   }
 
-  handleScenarioChange = (event) => {
-    this.setState({
-      scenario: Math.min(event.target.value - 1, SCENARIO_DEFINITIONS.length - 1),
-    });
+  handleScenarioChange = (scenario) => {
+    this.setState({ scenario });
   }
 
   render() {
@@ -39,13 +38,9 @@ export default class ScenarioList extends React.Component {
           value={this.state.level}
           onChange={this.handleLevelChange}
         />
-        <li>Select scenario number</li>
-        <input
-          max={SCENARIO_DEFINITIONS.length.toString()}
-          min="1"
-          name="scenario_number"
-          type="number"
-          value={this.state.scenario + 1}
+        <ScenarioSelector
+          text="Select scenario number"
+          value={this.state.scenario}
           onChange={this.handleScenarioChange}
         />
       </ul>

--- a/ScenarioList.jsx
+++ b/ScenarioList.jsx
@@ -11,7 +11,7 @@ export default class ScenarioList extends React.Component {
   state = { level: 1, scenario: 1 };
 
   getScenarioDecks() {
-    const { decks, special_rules: specialRules = [] } = SCENARIO_DEFINITIONS[this.state.scenario-1];
+    const { decks, special_rules: specialRules = [] } = SCENARIO_DEFINITIONS[this.state.scenario - 1];
     return decks.map(({ name }) => {
       let level = this.state.level;
       if ((specialRules.indexOf(SPECIAL_RULES.living_corpse_two_levels_extra) >= 0) && (name == SPECIAL_RULES.living_corpse_two_levels_extra.affected_deck)) {

--- a/ScenarioSelector.jsx
+++ b/ScenarioSelector.jsx
@@ -1,13 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import { SCENARIO_DEFINITIONS } from './scenarios';
+
 import { selectionList } from './style/SettingsPane.scss';
 
-const MAX_LEVEL = 7;
-
-export default class LevelSelector extends React.Component {
+export default class ScenarioSelector extends React.Component {
   static propTypes = {
-    inline: PropTypes.bool.isRequired,
     text: PropTypes.string.isRequired,
     value: PropTypes.number.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -19,35 +18,30 @@ export default class LevelSelector extends React.Component {
   }
 
   render() {
-    const Wrapper = this.props.inline ? 'span' : 'ul';
-    const Label = this.props.inline ? 'label' : 'li';
-
     const onChange = (event) => {
       if (event.target.value == '') {
         this.setState({ textValue: event.target.value });
         return;
       }
 
-      // We take the value mod 10, so that we can make the latest entered digit override
-      // the field value
-      let value = parseInt(event.target.value) % 10;
+      let value = parseInt(event.target.value);
       if (isNaN(value) || value < 0) {
         value = 0;
-      } else if (value > MAX_LEVEL) {
-        value = MAX_LEVEL;
+      } else if (value >= SCENARIO_DEFINITIONS.length) {
+        value = SCENARIO_DEFINITIONS.length;
       }
       this.setState({ textValue: value });
 
       this.props.onChange(value);
     };
-
+    
     const handleFocus = (event) => event.target.select();
 
     return (
-      <Wrapper className={selectionList}>
-      <Label>{this.props.text}</Label>
+      <ul className={selectionList}>
+      <li>{this.props.text}</li>
       <input
-      name="scenario_level"
+      name="scenario_number"
       type="text"
       pattern="[0-9]*"
       inputmode="numeric"
@@ -55,7 +49,8 @@ export default class LevelSelector extends React.Component {
       onChange={onChange}
       onFocus={handleFocus}
       />
-      </Wrapper>
+      </ul>
     );
   }
 }
+

--- a/ScenarioSelector.jsx
+++ b/ScenarioSelector.jsx
@@ -34,21 +34,21 @@ export default class ScenarioSelector extends React.Component {
 
       this.props.onChange(value);
     };
-    
-    const handleFocus = (event) => event.target.select();
+
+    const handleFocus = event => event.target.select();
 
     return (
       <ul className={selectionList}>
-      <li>{this.props.text}</li>
-      <input
-      name="scenario_number"
-      type="text"
-      pattern="[0-9]*"
-      inputmode="numeric"
-      value={this.state.textValue}
-      onChange={onChange}
-      onFocus={handleFocus}
-      />
+        <li>{this.props.text}</li>
+        <input
+          name="scenario_number"
+          type="text"
+          pattern="[0-9]*"
+          inputMode="numeric"
+          value={this.state.textValue}
+          onChange={onChange}
+          onFocus={handleFocus}
+        />
       </ul>
     );
   }

--- a/ScenarioSelector.jsx
+++ b/ScenarioSelector.jsx
@@ -25,7 +25,7 @@ export default class ScenarioSelector extends React.Component {
       }
 
       let value = parseInt(event.target.value);
-      if (isNaN(value) || value < 0) {
+      if (Number.isNaN(value) || value < 0) {
         value = 0;
       } else if (value >= SCENARIO_DEFINITIONS.length) {
         value = SCENARIO_DEFINITIONS.length;


### PR DESCRIPTION
This modifies both selectors to provide select-all on focus and hints to
use numeric input methods.  Additionally, for the level selector, the
last digit entered will be used for the field value.

Fixes issue #11